### PR TITLE
Handle null service intents

### DIFF
--- a/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
+++ b/android/src/main/java/flutter/overlay/window/flutter_overlay_window/OverlayService.java
@@ -98,6 +98,12 @@ public class OverlayService extends Service implements View.OnTouchListener {
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
         mResources = getApplicationContext().getResources();
+
+        if (intent == null) {
+            Log.w("OverlayService", "Received null intent in onStartCommand");
+            return START_STICKY;
+        }
+
         int startX = intent.getIntExtra("startX", OverlayConstants.DEFAULT_XY);
         int startY = intent.getIntExtra("startY", OverlayConstants.DEFAULT_XY);
         boolean isCloseWindow = intent.getBooleanExtra(INTENT_EXTRA_IS_CLOSE_WINDOW, false);


### PR DESCRIPTION
## Summary
- guard against null `intent` in `OverlayService.onStartCommand`

## Testing
- `./gradlew test` *(fails: Unable to download Gradle)*
